### PR TITLE
Generalize IdMap over algorithms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 thiserror = "1.0.30"
 indexmap = "1.8.0"
 itertools = "0.10.1"
+rudy = "0.1.0"
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/src/algo/isomorphism/vf2/state.rs
+++ b/src/algo/isomorphism/vf2/state.rs
@@ -1,4 +1,4 @@
-use crate::provide::{Direction, EdgeProvider, NodeId, NodeIdMapProvider, NodeProvider};
+use crate::provide::{Direction, EdgeProvider, IdMap, NodeId, NodeProvider};
 
 use super::ListType;
 
@@ -83,17 +83,18 @@ impl IsomorphismType {
 // * `Dir`: Specifies wether G1 and G2 are directed or undirected.
 // * `G1`: The first.
 // * `G2`: The second graph.
-pub(crate) struct VF2State<'a, Dir, G1, G2>
+pub(crate) struct VF2State<'a, Dir, G1, G2, I>
 where
     Dir: Direction,
-    G1: NodeProvider<Dir = Dir> + EdgeProvider + NodeIdMapProvider,
-    G2: NodeProvider<Dir = Dir> + EdgeProvider + NodeIdMapProvider,
+    G1: NodeProvider<Dir = Dir> + EdgeProvider,
+    G2: NodeProvider<Dir = Dir> + EdgeProvider,
+    I: IdMap,
 {
     pub(crate) g1: &'a G1,
     pub(crate) g2: &'a G2,
 
-    pub(crate) id_map1: <G1 as NodeIdMapProvider>::NodeIdMap,
-    pub(crate) id_map2: <G2 as NodeIdMapProvider>::NodeIdMap,
+    pub(crate) id_map1: I,
+    pub(crate) id_map2: I,
 
     // The type of isomorphism to search for.
     pub(crate) isomorphism_type: IsomorphismType,
@@ -123,17 +124,24 @@ where
     pub(crate) in2_size: usize,  // Size of T2_in
 }
 
-impl<'a, Dir, G1, G2> VF2State<'a, Dir, G1, G2>
+impl<'a, Dir, G1, G2, I> VF2State<'a, Dir, G1, G2, I>
 where
     Dir: Direction,
-    G1: NodeProvider<Dir = Dir> + EdgeProvider + NodeIdMapProvider,
-    G2: NodeProvider<Dir = Dir> + EdgeProvider + NodeIdMapProvider,
+    G1: NodeProvider<Dir = Dir> + EdgeProvider,
+    G2: NodeProvider<Dir = Dir> + EdgeProvider,
+    I: IdMap,
 {
     // # Arguments
     // * `g1`: First graph.
     // * `g2`: Second graph.
     // * `isomorphism_type`: The type of isomorphism to search for.
-    pub(crate) fn init(g1: &'a G1, g2: &'a G2, isomorphism_type: IsomorphismType) -> Self {
+    pub(crate) fn init(
+        g1: &'a G1,
+        g2: &'a G2,
+        id_map1: I,
+        id_map2: I,
+        isomorphism_type: IsomorphismType,
+    ) -> Self {
         let g1_node_count = g1.node_count();
         let g2_node_count = g2.node_count();
 
@@ -141,8 +149,8 @@ where
             g1,
             g2,
 
-            id_map1: g1.id_map(),
-            id_map2: g2.id_map(),
+            id_map1,
+            id_map2,
 
             isomorphism_type,
 

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -1,6 +1,5 @@
-pub mod traversal;
-pub mod isomorphism;
 mod err;
+pub mod isomorphism;
+pub mod traversal;
 
 pub use err::*;
-

--- a/src/algo/traversal/mod.rs
+++ b/src/algo/traversal/mod.rs
@@ -1,2 +1,1 @@
 pub mod dfs;
-

--- a/src/provide/id_map.rs
+++ b/src/provide/id_map.rs
@@ -1,5 +1,4 @@
 use rudy::rudymap::RudyMap;
-use std::collections::HashMap;
 use std::ops::Index;
 
 use itertools::Itertools;
@@ -13,49 +12,11 @@ pub trait IdMap<VirtId = usize, RealId = NodeId>:
 }
 
 pub struct DefaultIdMap {
-    real_to_virt: HashMap<NodeId, usize>,
-    virt_to_real: Vec<NodeId>,
-}
-
-impl IdMap for DefaultIdMap {
-    fn new(graph: &impl NodeProvider) -> Self {
-        let virt_to_real = graph.nodes().collect_vec();
-        let real_to_virt = virt_to_real
-            .iter()
-            .copied()
-            .enumerate()
-            .map(|(index, node)| (node, index))
-            .collect();
-
-        Self {
-            real_to_virt,
-            virt_to_real,
-        }
-    }
-}
-
-impl Index<NodeId> for DefaultIdMap {
-    type Output = usize;
-
-    fn index(&self, index: NodeId) -> &Self::Output {
-        &self.real_to_virt[&index]
-    }
-}
-
-impl Index<usize> for DefaultIdMap {
-    type Output = NodeId;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.virt_to_real[index]
-    }
-}
-
-pub struct RudyIdMap {
     real_to_virt: RudyMap<NodeId, usize>,
     virt_to_real: Vec<NodeId>,
 }
 
-impl IdMap for RudyIdMap {
+impl IdMap for DefaultIdMap {
     fn new(graph: &impl NodeProvider) -> Self {
         let virt_to_real = graph.nodes().collect_vec();
         let mut real_to_virt = RudyMap::new();
@@ -73,7 +34,7 @@ impl IdMap for RudyIdMap {
     }
 }
 
-impl Index<NodeId> for RudyIdMap {
+impl Index<NodeId> for DefaultIdMap {
     type Output = usize;
 
     fn index(&self, index: NodeId) -> &Self::Output {
@@ -81,7 +42,7 @@ impl Index<NodeId> for RudyIdMap {
     }
 }
 
-impl Index<usize> for RudyIdMap {
+impl Index<usize> for DefaultIdMap {
     type Output = NodeId;
 
     fn index(&self, index: usize) -> &Self::Output {

--- a/src/provide/id_map.rs
+++ b/src/provide/id_map.rs
@@ -1,3 +1,4 @@
+use rudy::rudymap::RudyMap;
 use std::collections::HashMap;
 use std::ops::Index;
 
@@ -46,5 +47,56 @@ impl Index<usize> for DefaultIdMap {
 
     fn index(&self, index: usize) -> &Self::Output {
         &self.virt_to_real[index]
+    }
+}
+
+pub struct RudyIdMap {
+    real_to_virt: RudyMap<NodeId, usize>,
+    virt_to_real: Vec<NodeId>,
+}
+
+impl IdMap for RudyIdMap {
+    fn new(graph: &impl NodeProvider) -> Self {
+        let virt_to_real = graph.nodes().collect_vec();
+        let mut real_to_virt = RudyMap::new();
+        let success = virt_to_real
+            .iter()
+            .enumerate()
+            .map(|(index, node)| real_to_virt.insert(*node, index))
+            .all(|duplicated| duplicated.is_none());
+        debug_assert!(success);
+
+        Self {
+            real_to_virt,
+            virt_to_real,
+        }
+    }
+}
+
+impl Index<NodeId> for RudyIdMap {
+    type Output = usize;
+
+    fn index(&self, index: NodeId) -> &Self::Output {
+        &self.real_to_virt.get(index).unwrap()
+    }
+}
+
+impl Index<usize> for RudyIdMap {
+    type Output = NodeId;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.virt_to_real[index]
+    }
+}
+
+impl rudy::Key for NodeId {
+    type Bytes = <usize as rudy::Key>::Bytes;
+
+    fn into_bytes(self) -> Self::Bytes {
+        self.0.into_bytes()
+    }
+
+    fn from_bytes(bytes: Self::Bytes) -> Self {
+        Self::from(usize::from_bytes(bytes))
     }
 }

--- a/src/provide/mod.rs
+++ b/src/provide/mod.rs
@@ -13,4 +13,3 @@ pub use node::*;
 pub use storage::*;
 
 pub(crate) mod test_util;
-

--- a/src/provide/node.rs
+++ b/src/provide/node.rs
@@ -2,7 +2,7 @@ use std::ops::{Add, Range, Sub};
 
 use super::{ProviderError, Storage};
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
+#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub struct NodeId(pub(crate) usize);
 
 impl NodeId {

--- a/src/storage/adj_map/mod.rs
+++ b/src/storage/adj_map/mod.rs
@@ -9,7 +9,7 @@ use indexmap::{IndexMap, IndexSet};
 
 use crate::provide::{
     AddEdgeProvider, AddNodeProvider, DelEdgeProvider, DelNodeProvider, Direction, EdgeProvider,
-    EmptyStorage, NodeId, NodeProvider, Orientation, Storage, NodeIdMapProvider, DefaultIdMap,
+    EmptyStorage, NodeId, NodeProvider, Orientation, Storage,
 };
 
 #[derive(Debug, Clone)]
@@ -241,14 +241,6 @@ impl<Dir: Direction> DelEdgeProvider for AdjMap<Dir> {
                 }
             })
             .unwrap();
-    }
-}
-
-impl<Dir: Direction> NodeIdMapProvider for AdjMap<Dir> {
-    type NodeIdMap = DefaultIdMap;
-
-    fn id_map(&self) -> Self::NodeIdMap {
-        DefaultIdMap::new(self.nodes())
     }
 }
 

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -1,10 +1,10 @@
+mod directed_view;
 mod generic_view;
 mod reverse_view;
-mod directed_view;
 
+pub use directed_view::*;
 pub use generic_view::*;
 pub use reverse_view::*;
-pub use directed_view::*;
 
 use crate::provide::{EdgeProvider, NodeProvider};
 


### PR DESCRIPTION
Close issue #3.

The trait `IdMap` ends up with the definition to avoid verbosely generalizing over algorithms.
```rust
pub trait IdMap<VirtId = usize, RealId = NodeId>:
    Index<VirtId, Output = RealId> + Index<RealId, Output = VirtId>
{
    fn new(graph: &impl NodeProvider) -> Self;
}
```